### PR TITLE
Fix inline alt screen & test/examples

### DIFF
--- a/examples/alt_screen.zig
+++ b/examples/alt_screen.zig
@@ -2,12 +2,15 @@ const std = @import("std");
 const zterm = @import("zterm");
 
 pub fn main() !void {
-    zterm.altScreen.enable();
-    defer zterm.altScreen.disable();
+    zterm.altScreen.print.enable();
+    defer zterm.altScreen.print.disable();
 
     std.debug.print("Hello from the Alternate Screen!\n", .{});
     std.debug.print("You should see this text on a blank screen.\n", .{});
     std.debug.print("Press Enter to return to your original terminal.\n", .{});
+    std.debug.print("You are on the Alt Screen: {}\n", .{zterm.altScreen.isEnabled()});
+
+    // You can also use 'std.debug.print("{s}", .{zterm.altScreen.{enable/disable}})'
 
     const orig_termios = try zterm.rawMode.enable();
     defer zterm.rawMode.disable(orig_termios) catch unreachable;

--- a/src/zterm.zig
+++ b/src/zterm.zig
@@ -411,14 +411,14 @@ pub const altScreen = struct {
         }
     };
 
-    pub inline fn enable() void {
-        utils.printEscapeCode("?1049h", .{});
+    pub inline fn enable() []const u8 {
         altScreen.enabled = true;
+        return utils.returnEscapeCode("?1049h", .{});
     }
 
-    pub inline fn disable() void {
-        utils.printEscapeCode("?1049l", .{});
+    pub inline fn disable() []const u8 {
         altScreen.enabled = false;
+        return utils.returnEscapeCode("?1049l", .{});
     }
 
     pub inline fn isEnabled() bool {


### PR DESCRIPTION
# Updates
- fix inline functions to actually return escape codes instead of printing them
- add more verbose examples